### PR TITLE
Add weekly calendar UI

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,44 +1,20 @@
 import { useState } from 'react';
+import WeeklyCalendar, { slotToTime } from './WeeklyCalendar';
 
 function App() {
-  const [records, setRecords] = useState([
-    { id: 1, task: '資料作成', start: '09:00', end: '10:30' },
-    { id: 2, task: '会議', start: '11:00', end: '12:00' },
-  ]);
-  const [task, setTask] = useState('');
-  const [start, setStart] = useState('');
-  const [end, setEnd] = useState('');
+  const [records, setRecords] = useState([]);
 
-  const addRecord = (e) => {
-    e.preventDefault();
-    if (!task || !start || !end) return;
-    setRecords([...records, { id: Date.now(), task, start, end }]);
-    setTask('');
-    setStart('');
-    setEnd('');
+  const addRecord = ({ day, startSlot, endSlot, task }) => {
+    setRecords((prev) => [
+      ...prev,
+      { id: Date.now(), day, startSlot, endSlot, task },
+    ]);
   };
 
   return (
     <div>
       <h1>作業時間記録アプリ</h1>
-      <form onSubmit={addRecord}>
-        <input
-          placeholder="作業内容"
-          value={task}
-          onChange={(e) => setTask(e.target.value)}
-        />
-        <input
-          type="time"
-          value={start}
-          onChange={(e) => setStart(e.target.value)}
-        />
-        <input
-          type="time"
-          value={end}
-          onChange={(e) => setEnd(e.target.value)}
-        />
-        <button type="submit">追加</button>
-      </form>
+      <WeeklyCalendar records={records} addRecord={addRecord} />
       <table>
         <thead>
           <tr>
@@ -51,8 +27,8 @@ function App() {
           {records.map((r) => (
             <tr key={r.id}>
               <td>{r.task}</td>
-              <td>{r.start}</td>
-              <td>{r.end}</td>
+              <td>{slotToTime(r.startSlot)}</td>
+              <td>{slotToTime(r.endSlot)}</td>
             </tr>
           ))}
         </tbody>

--- a/src/WeeklyCalendar.jsx
+++ b/src/WeeklyCalendar.jsx
@@ -1,0 +1,103 @@
+import { useState } from 'react';
+
+const days = ['月', '火', '水', '木', '金'];
+
+// 30分刻みで 8:00 - 18:00 までのスロット
+const slotCount = 20; // 10時間 * 2
+
+const slotToTime = (slot) => {
+  const hour = 8 + Math.floor(slot / 2);
+  const min = slot % 2 === 0 ? '00' : '30';
+  return `${hour.toString().padStart(2, '0')}:${min}`;
+};
+
+function WeeklyCalendar({ records, addRecord }) {
+  const [drag, setDrag] = useState(null); // {day, start}
+  const [hover, setHover] = useState(null); // {day, end}
+
+  const handleMouseDown = (day, slot) => {
+    setDrag({ day, start: slot });
+    setHover({ day, end: slot });
+  };
+
+  const handleMouseEnter = (day, slot) => {
+    if (drag) {
+      setHover({ day, end: slot });
+    }
+  };
+
+  const clearDrag = () => {
+    setDrag(null);
+    setHover(null);
+  };
+
+  const handleMouseUp = () => {
+    if (drag && hover && drag.day === hover.day) {
+      const day = drag.day;
+      const startSlot = Math.min(drag.start, hover.end);
+      const endSlot = Math.max(drag.start, hover.end) + 1;
+      if (startSlot !== endSlot) {
+        const task = window.prompt('作業内容を入力してください');
+        if (task) {
+          addRecord({ day, startSlot, endSlot, task });
+        }
+      }
+    }
+    clearDrag();
+  };
+
+  const isSelected = (day, slot) => {
+    if (!drag || !hover) return false;
+    if (day !== drag.day || day !== hover.day) return false;
+    const start = Math.min(drag.start, hover.end);
+    const end = Math.max(drag.start, hover.end);
+    return slot >= start && slot <= end;
+  };
+
+  return (
+    <div className="calendar" onMouseUp={handleMouseUp} onMouseLeave={clearDrag}>
+      <div className="header">
+        {days.map((d) => (
+          <div key={d} className="day-header">
+            {d}
+          </div>
+        ))}
+      </div>
+      <div className="body">
+        {days.map((d, dayIndex) => (
+          <div key={d} className="day-column">
+            {[...Array(slotCount)].map((_, slotIndex) => (
+              <div
+                key={slotIndex}
+                className={`slot ${isSelected(dayIndex, slotIndex) ? 'selected' : ''}`}
+                onMouseDown={() => handleMouseDown(dayIndex, slotIndex)}
+                onMouseEnter={() => handleMouseEnter(dayIndex, slotIndex)}
+              >
+                {slotIndex % 2 === 0 && (
+                  <span className="time-label">{slotToTime(slotIndex)}</span>
+                )}
+              </div>
+            ))}
+            {records
+              .filter((r) => r.day === dayIndex)
+              .map((r) => (
+                <div
+                  key={r.id}
+                  className="record"
+                  style={{
+                    top: r.startSlot * 30,
+                    height: (r.endSlot - r.startSlot) * 30,
+                  }}
+                >
+                  {r.task}
+                </div>
+              ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export { slotToTime };
+export default WeeklyCalendar;

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,59 @@
+body {
+  font-family: sans-serif;
+  margin: 20px;
+}
+
+.calendar {
+  user-select: none;
+}
+
+.header {
+  display: flex;
+}
+
+.day-header {
+  flex: 1;
+  text-align: center;
+  border: 1px solid #ccc;
+  padding: 4px 0;
+  background: #f0f0f0;
+  font-weight: bold;
+}
+
+.body {
+  display: flex;
+}
+
+.day-column {
+  flex: 1;
+  position: relative;
+  border: 1px solid #ccc;
+}
+
+.slot {
+  height: 30px;
+  border-bottom: 1px solid #eee;
+  position: relative;
+}
+
+.slot.selected {
+  background: rgba(0, 123, 255, 0.3);
+}
+
+.time-label {
+  position: absolute;
+  left: 2px;
+  font-size: 10px;
+  color: #888;
+}
+
+.record {
+  position: absolute;
+  left: 0;
+  right: 0;
+  background: rgba(0, 123, 255, 0.6);
+  color: #fff;
+  font-size: 12px;
+  padding-left: 2px;
+  box-sizing: border-box;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>


### PR DESCRIPTION
## Summary
- implement WeeklyCalendar with drag selection
- display calendar in `App` and list entries
- add basic styles and CSS import

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68526fb5f05c832e82db690761f13fb5